### PR TITLE
Fixing dependency to grunt-contrib-jscs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "devDependencies": {
         "grunt": "latest",
-        "grunt-contrib-jscs": "latest",
+        "grunt-jscodesniffer": "latest",
         "grunt-contrib-jshint": "latest",
         "grunt-jscs": "latest",
         "load-grunt-tasks": "latest"


### PR DESCRIPTION
It looks like grunt-contrib-jscs was removed from the npm repository and was replaced with https://github.com/dsheiko/grunt-jscodesniffer

> Note: This used to be called 'grunt-contrib-jscs' in the npm registry, but as of version 0.1.10 it has taken over the 'grunt-jscodesniffer' name.

That's why npm install cannot install all dependencies:

```
npm WARN package.json Node-Mayhem@0.1.0 No repository field.
npm ERR! Windows_NT 6.3.9600
npm ERR! argv "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\
\bin\\npm-cli.js" "install"
npm ERR! node v0.12.0
npm ERR! npm  v2.5.1
npm ERR! code E404

npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/grunt-contrib-jscs
npm ERR! 404
npm ERR! 404 'grunt-contrib-jscs' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 It was specified as a dependency of 'Node-Mayhem'
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! Please include the following file with any support request:
npm ERR!     c:\Git\hel\Node-Mayhem\npm-debug.log
```

I'm replacing dependency to grunt-contrib-jscs with grunt-jscodesniffer, it unblocks npm install